### PR TITLE
Option to generate files with untranslated strings only

### DIFF
--- a/lib/twine/cli.rb
+++ b/lib/twine/cli.rb
@@ -61,6 +61,9 @@ module Twine
         opts.on('-s', '--include-untranslated', 'This flag will cause any Android string files that are generated to include strings that have not yet been translated for the current language.') do |s|
           @options[:include_untranslated] = true
         end
+        opts.on('-l', '--only-untranslated', 'This flag will cause any Apple string files that are generated to include ONLY the strings that have not been translated.') do |c|
+            @options[:only_untranslated] = true
+        end
         opts.on('-o', '--output-file OUTPUT_FILE', 'Write the new strings database to this file instead of replacing the original file. This flag is only useful when running the consume-string-file or consume-loc-drop commands.') do |o|
           @options[:output_path] = o
         end

--- a/lib/twine/formatters/apple.rb
+++ b/lib/twine/formatters/apple.rb
@@ -1,3 +1,4 @@
+require 'cgi'
 module Twine
   module Formatters
     class Apple < Abstract
@@ -99,8 +100,16 @@ module Twine
 
                 key = row.key
                 key = key.gsub('"', '\\\\"')
-
+                                         
                 value = row.translated_string_for_lang(lang, default_lang)
+                                                  
+                if @options[:only_untranslated]
+                  valuelang = row.translated_string_for_lang(lang, lang)
+                  if valuelang
+                    value = nil;
+                  end
+                end
+                                                  
                 if value
                   value = value.gsub('"', '\\\\"')
 


### PR DESCRIPTION
Added an option to generate Apple string files only with the strings that are not translated.

The typical use case for this is incremental translation of an existing app.
This will extract only the strings that are not translated, and the generated file can be sent to a translator or an online translation service.

It's specially useful for online translation services where you can upload directly the Localizable.strings file. 

This way you don't need to find or extract manually the strings that need to be translated.


