### PR TITLE
Compatibility for newer versions of rubyzip

### DIFF
--- a/lib/twine/runner.rb
+++ b/lib/twine/runner.rb
@@ -148,7 +148,7 @@ module Twine
 
     def generate_loc_drop
       begin
-        require 'zip/zip'
+        require 'zip'
       rescue LoadError
         raise Twine::Error.new "You must run 'gem install rubyzip' in order to create or consume localization drops."
       end
@@ -158,7 +158,7 @@ module Twine
       end
 
       Dir.mktmpdir do |dir|
-        Zip::ZipFile.open(@options[:output_path], Zip::ZipFile::CREATE) do |zipfile|
+        Zip::File.open(@options[:output_path], Zip::File::CREATE) do |zipfile|
           zipfile.mkdir('Locales')
 
           formatter = formatter_for_format(@options[:format])
@@ -181,13 +181,13 @@ module Twine
       end
 
       begin
-        require 'zip/zip'
+        require 'zip'
       rescue LoadError
         raise Twine::Error.new "You must run 'gem install rubyzip' in order to create or consume localization drops."
       end
 
       Dir.mktmpdir do |dir|
-        Zip::ZipFile.open(@options[:input_path]) do |zipfile|
+        Zip::File.open(@options[:input_path]) do |zipfile|
           zipfile.each do |entry|
             if !entry.name.end_with?'/' and !File.basename(entry.name).start_with?'.'
               real_path = File.join(dir, entry.name)


### PR DESCRIPTION
Using newer version of rubyzip syntax as found in recent versions of rubyzip https://github.com/rubyzip/rubyzip/blob/master/README.md

This addresses https://github.com/mobiata/twine/issues/76