### PR TITLE
Add `validate-strings-file` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ This command gives you useful information about your strings. It will tell you h
 
 	$ twine generate-report /path/to/strings.txt
 
+#### `validate-strings-file`
+
+This command validates that the strings file can be parsed, contains no duplicate keys, and that all strings have at least one tag. It will exit with a status code other than zero if any of those criteria are not met.
+
+	$ twine validate-strings-file /path/to/strings.txt
+
 ## Creating Your First strings.txt File
 
 The easiest way to create your first strings.txt file is to run the `consume-all-string-files` command. The one caveat is to first create a blank strings.txt file to use as your starting point. Then, just point the `consume-all-string-files` command at a directory in your project containing all of your iOS, OS X, or Android strings files.

--- a/README.md
+++ b/README.md
@@ -130,13 +130,13 @@ This command is a convenient way of taking a zip file and executing the `consume
 
 #### `generate-report`
 
-This command gives you useful information about your strings. It will tell you how many strings you have, how many have been translated into each language, and whether your master strings data file has any duplicate string keys.
+This command gives you useful information about your strings. It will tell you how many strings you have and how many have been translated into each language.
 
 	$ twine generate-report /path/to/strings.txt
 
 #### `validate-strings-file`
 
-This command validates that the strings file can be parsed, contains no duplicate keys, and that all strings have at least one tag. It will exit with a status code other than zero if any of those criteria are not met.
+This command validates that the strings file can be parsed, contains no duplicate keys, and that all strings have at least one tag. It will exit with a non-zero status code if any of those criteria are not met.
 
 	$ twine validate-strings-file /path/to/strings.txt
 

--- a/lib/twine/cli.rb
+++ b/lib/twine/cli.rb
@@ -33,6 +33,8 @@ module Twine
         opts.separator ''
         opts.separator 'generate-report -- Generates a report containing data about your strings. For example, it will tell you if you have any duplicate strings or if any of your strings are missing tags. In addition, it will tell you how many strings you have and how many of those strings have been translated into each language.'
         opts.separator ''
+        opts.separator 'validate-strings-file -- Validates that the given strings file is parseable, contains no duplicates, and that every string has a tag. Exits with a non-zero exit code if those criteria are not met.'
+        opts.separator ''
         opts.separator 'General Options:'
         opts.separator ''
         opts.on('-l', '--lang LANGUAGES', Array, 'The language code(s) to use for the specified action.') do |langs|
@@ -97,6 +99,7 @@ module Twine
         opts.separator '> twine generate-loc-drop strings.txt LocDrop5.zip --tags FT,FB --format android --lang de,en,en-GB,ja,ko'
         opts.separator '> twine consume-loc-drop strings.txt LocDrop5.zip'
         opts.separator '> twine generate-report strings.txt'
+        opts.separator '> twine validate-strings-file strings.txt'
       end
       parser.parse! @args
 

--- a/lib/twine/cli.rb
+++ b/lib/twine/cli.rb
@@ -31,7 +31,7 @@ module Twine
         opts.separator ''
         opts.separator 'consume-loc-drop -- Consumes an archive of translated files. This archive should be in the same format as the one created by the generate-loc-drop command.'
         opts.separator ''
-        opts.separator 'generate-report -- Generates a report containing data about your strings. For example, it will tell you if you have any duplicate strings or if any of your strings are missing tags. In addition, it will tell you how many strings you have and how many of those strings have been translated into each language.'
+        opts.separator 'generate-report -- Generates a report containing data about your strings. It will tell you how many strings you have and how many of those strings have been translated into each language.'
         opts.separator ''
         opts.separator 'validate-strings-file -- Validates that the given strings file is parseable, contains no duplicates, and that every string has a tag. Exits with a non-zero exit code if those criteria are not met.'
         opts.separator ''

--- a/lib/twine/runner.rb
+++ b/lib/twine/runner.rb
@@ -238,6 +238,7 @@ module Twine
       all_keys = Set.new
       duplicate_keys = Set.new
       keys_without_tags = Set.new
+      errors = []
 
       @strings.sections.each do |section|
         section.rows.each do |row|
@@ -257,14 +258,18 @@ module Twine
 
       if duplicate_keys.length > 0
         error_body = duplicate_keys.to_a.join("\n  ")
-        raise Twine::Error.new "Found duplicate string key(s):\n  #{error_body}"
+        errors << "Found duplicate string key(s):\n  #{error_body}"
       end
 
       if keys_without_tags.length == total_strings
-        raise Twine::Error.new "None of your strings have tags."
+        errors << "None of your strings have tags."
       elsif keys_without_tags.length > 0
         error_body = keys_without_tags.to_a.join("\n  ")
-        raise Twine::Error.new "Found strings(s) without tags:\n  #{error_body}"
+        errors << "Found strings(s) without tags:\n  #{error_body}"
+      end
+
+      if errors.length > 0
+        raise Twine::Error.new errors.join("\n\n")
       end
 
       puts "#{@options[:strings_file]} is valid."

--- a/lib/twine/runner.rb
+++ b/lib/twine/runner.rb
@@ -212,9 +212,6 @@ module Twine
     def generate_report
       total_strings = 0
       strings_per_lang = {}
-      all_keys = Set.new
-      duplicate_keys = Set.new
-      keys_without_tags = Set.new
       @strings.language_codes.each do |code|
         strings_per_lang[code] = 0
       end
@@ -223,18 +220,8 @@ module Twine
         section.rows.each do |row|
           total_strings += 1
 
-          if all_keys.include? row.key
-            duplicate_keys.add(row.key)
-          else
-            all_keys.add(row.key)
-          end
-
           row.translations.each_key do |code|
             strings_per_lang[code] += 1
-          end
-
-          if row.tags == nil || row.tags.length == 0
-            keys_without_tags.add(row.key)
           end
         end
       end
@@ -243,22 +230,6 @@ module Twine
       puts "Total number of strings = #{total_strings}"
       @strings.language_codes.each do |code|
         puts "#{code}: #{strings_per_lang[code]}"
-      end
-
-      if duplicate_keys.length > 0
-        puts "\nDuplicate string keys:"
-        duplicate_keys.each do |key|
-          puts key
-        end
-      end
-
-      if keys_without_tags.length == total_strings
-        puts "\nNone of your strings have tags."
-      elsif keys_without_tags.length > 0
-        puts "\nStrings without tags:"
-        keys_without_tags.each do |key|
-          puts key
-        end
       end
     end
 


### PR DESCRIPTION
`validate-strings-file` checks for duplicate keys or keys without tags and will exit with a non-zero status code if either of those checks are true.