### PR TITLE
Extracted reference lookups from StringsFile

### DIFF
--- a/lib/twine/formatters/abstract.rb
+++ b/lib/twine/formatters/abstract.rb
@@ -72,7 +72,12 @@ module Twine
       
       def set_translation_for_key(key, lang, value)
         if @strings.strings_map.include?(key)
-          @strings.strings_map[key].translations[lang] = value
+          row = @strings.strings_map[key]
+          reference = @strings.strings_map[row.reference_key] if row.reference_key
+
+          if !reference or value != reference.translations[lang]
+            row.translations[lang] = value
+          end
         elsif @options[:consume_all]
           STDERR.puts "Adding new string '#{key}' to strings data file."
           arr = @strings.sections.select { |s| s.name == 'Uncategorized' }
@@ -100,7 +105,13 @@ module Twine
 
       def set_comment_for_key(key, comment)
         if @strings.strings_map.include?(key)
-          @strings.strings_map[key].comment = comment
+          row = @strings.strings_map[key]
+          
+          reference = @strings.strings_map[row.reference_key] if row.reference_key
+
+          if !reference or comment != reference.raw_comment
+            row.comment = comment
+          end
         end
       end
 

--- a/lib/twine/stringsfile.rb
+++ b/lib/twine/stringsfile.rb
@@ -200,11 +200,9 @@ module Twine
           f.puts "[[#{section.name}]]"
 
           section.rows.each do |row|
-            reference = @strings_map[row.reference_key] if row.reference_key
-
             f.puts "\t[#{row.key}]"
 
-            value = write_value(row, dev_lang, f, reference)
+            value = write_value(row, dev_lang, f)
             if !value && !row.reference_key
               puts "Warning: #{row.key} does not exist in developer language '#{dev_lang}'"
             end
@@ -216,11 +214,11 @@ module Twine
               tag_str = row.tags.join(',')
               f.puts "\t\ttags = #{tag_str}"
             end
-            if row.raw_comment and row.raw_comment.length > 0 and (!reference or row.raw_comment != reference.raw_comment)
+            if row.raw_comment and row.raw_comment.length > 0
               f.puts "\t\tcomment = #{row.raw_comment}"
             end
             @language_codes[1..-1].each do |lang|
-              write_value(row, lang, f, reference)
+              write_value(row, lang, f)
             end
           end
         end
@@ -229,7 +227,7 @@ module Twine
 
     private
 
-    def write_value(row, language, file, reference)
+    def write_value(row, language, file)
       value = row.translations[language]
       return nil unless value
 
@@ -237,9 +235,7 @@ module Twine
         value = '`' + value + '`'
       end
 
-      if !reference or value != reference.translations[language]
-        file.puts "\t\t#{language} = #{value}"
-      end
+      file.puts "\t\t#{language} = #{value}"
       return value
     end
 


### PR DESCRIPTION
The reference lookups used to be performed when writing a file. This bears the problem that the data structure itself does not represent the actual truth throughout its lifetime which makes it more complicated to use at least. 

This PR extracts the reference logic into `Abstract.set_translation_for_key` and `set_comment_for_key` which already perform similar actions. As a result `StringsFile` becomes more of a pure data structure (which is also easier to use and test) and similar tasks are performed together.

As usual, all test still pass.