### PR TITLE
FIX androidify_substitutions numbers multiple simple % characters

### DIFF
--- a/lib/twine/formatters/abstract.rb
+++ b/lib/twine/formatters/abstract.rb
@@ -39,7 +39,8 @@ module Twine
             elsif c.match(/\d/)
               # leave the string alone if it already has numbered substitutions
               return str
-            else
+            elsif c.match(/[ds]/)
+              # substitution for decimal (d) or string (s) found
               substituteCount += 1
             end
             startFound = false


### PR DESCRIPTION
Hi!

I've discovered this bug when "androidifying" strings. The string "Lorem ipsum **%** dolor sit **%** amet" resulted in the string "Lorem ipsum **%1$** dolor sit **%2$** amet", even though those are simple % characters and shouldn't be treated as substitutions.

I've added the additional check for the normally used placeholders *d* (decimal) and *s* (string), the script really only detects valid substitutions.