### PR TITLE
Use set_translation in formatters

### DIFF
--- a/lib/twine/formatters/android.rb
+++ b/lib/twine/formatters/android.rb
@@ -45,6 +45,15 @@ module Twine
         return
       end
 
+      def set_translation_for_key(key, lang, value)
+        value = CGI.unescapeHTML(value)
+        value.gsub!('\\\'', '\'')
+        value.gsub!('\\"', '"')
+        value = iosify_substitutions(value)
+        value.gsub!(/(\\u0020)*|(\\u0020)*\z/) { |spaces| ' ' * (spaces.length / 6) }
+        super(key, lang, value)
+      end
+
       def read_file(path, lang)
         resources_regex = /<resources(?:[^>]*)>(.*)<\/resources>/m
         key_regex = /<string name="(\w+)">/
@@ -62,16 +71,8 @@ module Twine
               if key_match
                 key = key_match[1]
                 value_match = value_regex.match(line)
-                if value_match
-                  value = value_match[1]
-                  value = CGI.unescapeHTML(value)
-                  value.gsub!('\\\'', '\'')
-                  value.gsub!('\\"', '"')
-                  value = iosify_substitutions(value)
-                  value.gsub!(/(\\u0020)*|(\\u0020)*\z/) { |spaces| ' ' * (spaces.length / 6) }
-                else
-                  value = ""
-                end
+                value = value_match ? value_match[1] : ""
+                
                 set_translation_for_key(key, lang, value)
                 if comment and comment.length > 0 and !comment.start_with?("SECTION:")
                   set_comment_for_key(key, comment)

--- a/lib/twine/formatters/jquery.rb
+++ b/lib/twine/formatters/jquery.rb
@@ -25,6 +25,11 @@ module Twine
         return
       end
 
+      def set_translation_for_key(key, lang, value)
+        value = value.gsub("\n","\\n")
+        super(key, lang, value)
+      end
+
       def read_file(path, lang)
         begin
           require "json"
@@ -35,7 +40,6 @@ module Twine
         open(path) do |io|
           json = JSON.load(io)
           json.each do |key, value|
-            value = value.gsub("\n","\\n")
             set_translation_for_key(key, lang, value)
           end
         end

--- a/test/test_formatters.rb
+++ b/test/test_formatters.rb
@@ -132,6 +132,12 @@ class TestJQueryFormatter < FormatterTest
     end
   end
 
+  def test_set_translation_escapes_newlines
+    @formatter.set_translation_for_key 'key1', 'en', "new\nline"
+
+    assert_equal 'new\nline', @strings.strings_map['key1'].translations['en']
+  end
+
   def test_write_file_output_format
     formatter = Twine::Formatters::JQuery.new @twine_file, {}
     formatter.write_file @output_path, 'en'


### PR DESCRIPTION
I think it makes sense to transform translations in `set_translation_for_key` instead of in `read_file`. It's a formatters job to perform any necessary input and output transformations, regardless of the way through which new data is added (reading a file or setting the values directly). 

This also improves testability because there's no need for a fixture to be read to test an input transformation.

@scelis, what do you think about this? Especially, should the `\n` -> `\\n` substitution of `JQuery.set_translation_for_key` be done in `Abstract`?