### PR TITLE
Change dependencies to be more permissive.

### DIFF
--- a/twine.gemspec
+++ b/twine.gemspec
@@ -18,11 +18,11 @@ Gem::Specification.new do |s|
   s.test_files   = Dir.glob("test/test_*")
 
   s.required_ruby_version = ">= 1.8.7"
-  s.add_runtime_dependency('rubyzip', "~> 1.1.7")
-  s.add_runtime_dependency('safe_yaml', "~> 1.0.3")
-  s.add_development_dependency('rake', "~> 0.9.2")
-  s.add_development_dependency('minitest', "> 5.5")
-  s.add_development_dependency('mocha', ">= 1.1")
+  s.add_runtime_dependency('rubyzip', "~> 1.1")
+  s.add_runtime_dependency('safe_yaml', "~> 1.0")
+  s.add_development_dependency('rake', "~> 10.4")
+  s.add_development_dependency('minitest', "~> 5.5")
+  s.add_development_dependency('mocha', "~> 1.1")
 
   s.executables  = %w( twine )
   s.description  = <<desc


### PR DESCRIPTION
Also use the latest version of rake.

My initial tests seem to show that everything works fine this way. If we
run into issues where some gems broke APIs between minor version bumps,
some of these dependencies might need to be locked down to more specific
versions.

@sebastianludwig 