### PR TITLE
Consume comments

### DIFF
--- a/lib/twine/formatters/abstract.rb
+++ b/lib/twine/formatters/abstract.rb
@@ -103,6 +103,8 @@ module Twine
       end
 
       def set_comment_for_key(key, comment)
+        return unless @options[:consume_comments]
+        
         if @strings.strings_map.include?(key)
           row = @strings.strings_map[key]
           

--- a/lib/twine/formatters/apple.rb
+++ b/lib/twine/formatters/apple.rb
@@ -74,14 +74,14 @@ module Twine
                 set_comment_for_key(key, last_comment)
               end
             end
-            if @options[:consume_comments]
-              match = /\/\* (.*) \*\//.match(line)
-              if match
-                last_comment = match[1]
-              else
-                last_comment = nil
-              end
+
+            match = /\/\* (.*) \*\//.match(line)
+            if match
+              last_comment = match[1]
+            else
+              last_comment = nil
             end
+
           end
         end
       end

--- a/lib/twine/formatters/django.rb
+++ b/lib/twine/formatters/django.rb
@@ -60,14 +60,12 @@ module Twine
                 line = Iconv.iconv('UTF-8', encoding, line).join
               end
             end
-            if @options[:consume_comments]
-               comment_match = comment_regex.match(line)
-               if comment_match
-                   comment = comment_match[1]
-               end
-            else
-                comment = nil
+            
+            comment_match = comment_regex.match(line)
+            if comment_match
+              comment = comment_match[1]
             end
+
             key_match = key_regex.match(line)
             if key_match
                 key = key_match[1].gsub('\\"', '"')

--- a/lib/twine/formatters/django.rb
+++ b/lib/twine/formatters/django.rb
@@ -26,7 +26,7 @@ module Twine
       end
 
       def read_file(path, lang)
-        comment_regex = /#.? *"(.*)"$/
+        comment_regex = /#\. *"?(.*)"?$/
         key_regex = /msgid *"(.*)"$/
         value_regex = /msgstr *"(.*)"$/m
 
@@ -83,6 +83,8 @@ module Twine
                 if comment and comment.length > 0 and !comment.start_with?("--------- ")
                     set_comment_for_key(key, comment)
                 end
+                key = nil
+                value = nil
                 comment = nil
             end
 

--- a/lib/twine/formatters/flash.rb
+++ b/lib/twine/formatters/flash.rb
@@ -59,7 +59,7 @@ module Twine
               end
             end
             if @options[:consume_comments]
-              match = /#(.*)/.match(line)
+              match = /# *(.*)/.match(line)
               if match
                 last_comment = match[1]
               else

--- a/lib/twine/formatters/flash.rb
+++ b/lib/twine/formatters/flash.rb
@@ -58,14 +58,14 @@ module Twine
                 set_comment_for_key(key, last_comment)
               end
             end
-            if @options[:consume_comments]
-              match = /# *(.*)/.match(line)
-              if match
-                last_comment = match[1]
-              else
-                last_comment = nil
-              end
+            
+            match = /# *(.*)/.match(line)
+            if match
+              last_comment = match[1]
+            else
+              last_comment = nil
             end
+
           end
         end
       end

--- a/test/test_abstract_formatter.rb
+++ b/test/test_abstract_formatter.rb
@@ -91,12 +91,28 @@ class TestAbstractFormatter < TwineTestCase
   end
 
   class SetComment < TwineTestCase
+    def setup
+      super
+
+      @strings = build_twine_file 'en' do
+        add_section 'Section' do
+          add_row key: 'value'
+        end
+      end
+    end
+
     def test_set_comment_for_key_does_not_update_comment
-      skip 'not supported by current implementation - see #97'
+      formatter = Twine::Formatters::Abstract.new(@strings, {})
+      formatter.set_comment_for_key('key', 'comment')
+
+      assert_nil formatter.strings.strings_map['key'].comment
     end
 
     def test_set_comment_for_key_updates_comment_with_update_comments
-      skip 'not supported by current implementation - see #97'
+      formatter = Twine::Formatters::Abstract.new(@strings, { consume_comments: true })
+      formatter.set_comment_for_key('key', 'comment')
+
+      assert_equal 'comment', formatter.strings.strings_map['key'].comment
     end
   end
 
@@ -104,14 +120,14 @@ class TestAbstractFormatter < TwineTestCase
     def setup
       super
 
-      @strings = build_twine_file 'en', 'fr' do
+      @strings = build_twine_file 'en' do
         add_section 'Section' do
           add_row refkey: 'ref-value', comment: 'reference comment'
           add_row key: 'value', ref: :refkey
         end
       end
 
-      @formatter = Twine::Formatters::Abstract.new(@strings, {})
+      @formatter = Twine::Formatters::Abstract.new(@strings, { consume_comments: true })
     end
 
     def test_set_comment_does_not_add_unchanged_comment

--- a/test/test_formatters.rb
+++ b/test/test_formatters.rb
@@ -17,7 +17,20 @@ class FormatterTest < TwineTestCase
     end
 
     @strings = Twine::StringsFile.new
-    @formatter = formatter_class.new @strings, { consume_all: true }
+    @formatter = formatter_class.new @strings, { consume_all: true, consume_comments: true }
+  end
+
+  def assert_translations_read_correctly
+    1.upto(4) do |i|
+      assert_equal "value#{i}-english", @strings.strings_map["key#{i}"].translations['en']
+    end
+  end
+
+  def assert_file_contents_read_correctly
+    assert_translations_read_correctly
+
+    assert_equal "comment key1", @strings.strings_map["key1"].comment
+    assert_equal "comment key4", @strings.strings_map["key4"].comment
   end
 end
 
@@ -29,9 +42,7 @@ class TestAndroidFormatter < FormatterTest
   def test_read_file_format
     @formatter.read_file fixture('formatter_android.xml'), 'en'
 
-    1.upto(4) do |i|
-      assert_equal "value#{i}-english", @strings.strings_map["key#{i}"].translations['en']
-    end
+    assert_file_contents_read_correctly
   end
 
   def test_set_translation_transforms_leading_spaces
@@ -94,9 +105,7 @@ class TestAppleFormatter < FormatterTest
   def test_read_file_format
     @formatter.read_file fixture('formatter_apple.strings'), 'en'
 
-    1.upto(4) do |i|
-      assert_equal "value#{i}-english", @strings.strings_map["key#{i}"].translations['en']
-    end
+    assert_file_contents_read_correctly
   end
 
   def test_write_file_output_format
@@ -127,9 +136,7 @@ class TestJQueryFormatter < FormatterTest
   def test_read_file_format
     @formatter.read_file fixture('formatter_jquery.json'), 'en'
 
-    1.upto(4) do |i|
-      assert_equal "value#{i}-english", @strings.strings_map["key#{i}"].translations['en']
-    end
+    assert_translations_read_correctly
   end
 
   def test_set_translation_escapes_newlines
@@ -159,9 +166,7 @@ class TestGettextFormatter < FormatterTest
   def test_read_file_format
     @formatter.read_file fixture('formatter_gettext.po'), 'en'
 
-    1.upto(4) do |i|
-      assert_equal "value#{i}-english", @strings.strings_map["key#{i}"].translations['en']
-    end
+    assert_file_contents_read_correctly
   end
 
   def test_read_file_with_multiple_line_value
@@ -188,9 +193,7 @@ class TestTizenFormatter < FormatterTest
     skip 'the current implementation of Tizen formatter does not support read_file'
     @formatter.read_file fixture('formatter_tizen.xml'), 'en'
 
-    1.upto(4) do |i|
-      assert_equal "value#{i}-english", @strings.strings_map["key#{i}"].translations['en']
-    end
+    assert_file_contents_read_correctly
   end
 
   def test_write_file_output_format
@@ -209,9 +212,7 @@ class TestDjangoFormatter < FormatterTest
   def test_read_file_format
     @formatter.read_file fixture('formatter_django.po'), 'en'
 
-    1.upto(4) do |i|
-      assert_equal "value#{i}-english", @strings.strings_map["key#{i}"].translations['en']
-    end
+    assert_file_contents_read_correctly
   end
 
   def test_write_file_output_format
@@ -229,9 +230,7 @@ class TestFlashFormatter < FormatterTest
   def test_read_file_format
     @formatter.read_file fixture('formatter_flash.properties'), 'en'
 
-    1.upto(4) do |i|
-      assert_equal "value#{i}-english", @strings.strings_map["key#{i}"].translations['en']
-    end
+    assert_file_contents_read_correctly
   end
 
   def test_write_file_output_format


### PR DESCRIPTION
Previously the `--consume-comments` option had to be evaluated by every formatter. The Android formatter did not support the option and always consumed comments. This PR moves the logic to `Abstract.set_comment_for_key`. This is in line with `set_translation_for_key` evaluating the `--consume-all` option and DRYs up the formatters. This closes #97.