### PR TITLE
Post modularization cleanup

### DIFF
--- a/lib/twine/output_processor.rb
+++ b/lib/twine/output_processor.rb
@@ -22,7 +22,7 @@ module Twine
       def process(language)
         result = StringsFile.new
 
-        @strings.language_codes.each { |lang| result.language_codes << lang }
+        result.language_codes.concat @strings.language_codes
         @strings.sections.each do |section|
           new_section = StringsSection.new section.name
 

--- a/lib/twine/stringsfile.rb
+++ b/lib/twine/stringsfile.rb
@@ -48,24 +48,12 @@ module Twine
       return false
     end
 
-    def translated_string_for_lang(lang, default_lang=nil)
+    def translated_string_for_lang(lang)
       translation = [lang].flatten.map { |l| @translations[l] }.first
 
-      translation = reference.translated_string_for_lang(lang, default_lang) if translation.nil? && reference
+      translation = reference.translated_string_for_lang(lang) if translation.nil? && reference
 
       return translation if translation
-      
-      # TODO: get rid of all this and the default_lang parameter once all formatters are converted to the new style
-      if default_lang.respond_to?("each")
-        default_lang.each do |def_lang|
-          if @translations[def_lang]
-            return @translations[def_lang]
-          end
-        end
-        return nil
-      elsif default_lang
-        return @translations[default_lang]
-      end
     end
   end
 

--- a/lib/twine/stringsfile.rb
+++ b/lib/twine/stringsfile.rb
@@ -53,7 +53,7 @@ module Twine
 
       translation = reference.translated_string_for_lang(lang) if translation.nil? && reference
 
-      return translation if translation
+      return translation
     end
   end
 

--- a/test/test_formatters.rb
+++ b/test/test_formatters.rb
@@ -145,8 +145,7 @@ class TestJQueryFormatter < FormatterTest
   end
 
   def test_format_value_with_newline
-    skip 'this test will only work once the JQuery formatter is modularized'
-    # assert_equal "value\nwith\nline\nbreaks", @formatter.format_value("value\nwith\nline\nbreaks")
+    assert_equal "value\nwith\nline\nbreaks", @formatter.format_value("value\nwith\nline\nbreaks")
   end
 end
 


### PR DESCRIPTION
With the #112 done, the `skip` reason of `test_format_value_with_newline` is gone and `StringsRow.set_translation_for_lang` can be simplified.