### PR TITLE
Newline escaping

### DIFF
--- a/lib/twine/formatters/abstract.rb
+++ b/lib/twine/formatters/abstract.rb
@@ -71,6 +71,8 @@ module Twine
       end
       
       def set_translation_for_key(key, lang, value)
+        value = value.gsub("\n", "\\n")
+
         if @strings.strings_map.include?(key)
           row = @strings.strings_map[key]
           reference = @strings.strings_map[row.reference_key] if row.reference_key

--- a/lib/twine/formatters/jquery.rb
+++ b/lib/twine/formatters/jquery.rb
@@ -25,11 +25,6 @@ module Twine
         return
       end
 
-      def set_translation_for_key(key, lang, value)
-        value = value.gsub("\n","\\n")
-        super(key, lang, value)
-      end
-
       def read_file(path, lang)
         begin
           require "json"

--- a/test/test_abstract_formatter.rb
+++ b/test/test_abstract_formatter.rb
@@ -27,6 +27,12 @@ class TestAbstractFormatter < TwineTestCase
       assert_equal 'value2-french', @strings.strings_map['key2'].translations['fr']
     end
 
+    def test_set_translation_escapes_newlines
+      @formatter.set_translation_for_key 'key1', 'en', "new\nline"
+
+      assert_equal 'new\nline', @strings.strings_map['key1'].translations['en']
+    end
+
     def test_set_translation_adds_translation_to_existing_key
       @formatter.set_translation_for_key 'key1', 'fr', 'value1-french'
 

--- a/test/test_formatters.rb
+++ b/test/test_formatters.rb
@@ -132,12 +132,6 @@ class TestJQueryFormatter < FormatterTest
     end
   end
 
-  def test_set_translation_escapes_newlines
-    @formatter.set_translation_for_key 'key1', 'en', "new\nline"
-
-    assert_equal 'new\nline', @strings.strings_map['key1'].translations['en']
-  end
-
   def test_write_file_output_format
     formatter = Twine::Formatters::JQuery.new @twine_file, {}
     formatter.write_file @output_path, 'en'


### PR DESCRIPTION
Because Twine does not support multi-line translations in its twine file, it's necessary to escape newline characters in `set_translation_for_key`. Previously only the JQuery formatter escaped parsed newlines properly. Loosely relates to #81.