### PR TITLE
Fixed Android language determination. Closes #134.

### DIFF
--- a/lib/twine/formatters/android.rb
+++ b/lib/twine/formatters/android.rb
@@ -39,7 +39,9 @@ module Twine
           if segment == 'values'
             return @strings.language_codes[0]
           else
-            match = /^values-(.*)$/.match(segment)
+            # The language is defined by a two-letter ISO 639-1 language code, optionally followed by a two letter ISO 3166-1-alpha-2 region code (preceded by lowercase "r").
+            # see http://developer.android.com/guide/topics/resources/providing-resources.html#AlternativeResources
+            match = /^values-([a-z]{2}(-r[a-z]{2})?)$/i.match(segment)
             if match
               lang = match[1]
               lang = LANG_CODES.fetch(lang, lang)

--- a/test/test_formatters.rb
+++ b/test/test_formatters.rb
@@ -106,6 +106,14 @@ class TestAndroidFormatter < FormatterTest
     assert_equal language, @formatter.determine_language_given_path("res/values-#{language}")
   end
 
+  def test_deducts_language_and_region_from_resource_folder
+    assert_equal 'de-AT', @formatter.determine_language_given_path("res/values-de-rAT")
+  end
+
+  def test_maps_laguage_deducted_from_resource_folder
+    assert_equal 'zh-Hans', @formatter.determine_language_given_path("res/values-zh-rCN")
+  end
+
   def test_does_not_deduct_language_from_device_capability_resource_folder
     assert_nil @formatter.determine_language_given_path('res/values-w820p')
   end

--- a/test/test_formatters.rb
+++ b/test/test_formatters.rb
@@ -100,6 +100,15 @@ class TestAndroidFormatter < FormatterTest
     identifier = '@android:string/cancel'
     assert_equal identifier, @formatter.format_value(identifier)
   end
+
+  def test_deducts_language_from_resource_folder
+    language = %w(en de fr).sample
+    assert_equal language, @formatter.determine_language_given_path("res/values-#{language}")
+  end
+
+  def test_does_not_deduct_language_from_device_capability_resource_folder
+    assert_nil @formatter.determine_language_given_path('res/values-w820p')
+  end
 end
 
 class TestAppleFormatter < FormatterTest


### PR DESCRIPTION
Previously anything after a `values-` prefix has been treated as a language. The regex is more restricted now to only allow for language code patterns as they are documented.