### PR TITLE
Add prefix "values-" to the folders generated for Android with the ar…

### DIFF
--- a/lib/twine/formatters/android.rb
+++ b/lib/twine/formatters/android.rb
@@ -25,6 +25,11 @@ module Twine
         '.xml'
       end
 
+
+      def output_path_for_language(lang)
+        "values-" + lang
+      end
+
       def can_handle_directory?(path)
         Dir.entries(path).any? { |item| /^values.*$/.match(item) }
       end


### PR DESCRIPTION
…gument "-r".

Currently the name generated for the language folders is not correct, since it has'nt contains the prefix "values-"