### PR TITLE
Better option parsing

### DIFF
--- a/lib/twine/cli.rb
+++ b/lib/twine/cli.rb
@@ -13,90 +13,103 @@ module Twine
     }
 
     def self.parse(args)
-      options = {}
+      options = { include: :all }
+
       parser = OptionParser.new do |opts|
         opts.banner = 'Usage: twine COMMAND STRINGS_FILE [INPUT_OR_OUTPUT_PATH] [--lang LANG1,LANG2...] [--tags TAG1,TAG2,TAG3...] [--format FORMAT]'
         opts.separator ''
-        opts.separator 'The purpose of this script is to convert back and forth between multiple data formats, allowing us to treat our strings (and translations) as data stored in a text file. We can then use the data file to create drops for the localization team, consume similar drops returned by the localization team, and create formatted string files to ship with your products. Twine currently supports iOS, OS X, Android, gettext, and jquery-localize string files.'
+        opts.separator 'The purpose of this script is to convert back and forth between multiple data formats, allowing us to treat our strings (and translations) as data stored in a text file. We can then use the data file to create drops for the localization team, consume similar drops returned by the localization team, and create formatted string files to ship with your products.'
         opts.separator ''
         opts.separator 'Commands:'
         opts.separator ''
-        opts.separator 'generate-string-file -- Generates a string file in a certain LANGUAGE given a particular FORMAT. This script will attempt to guess both the language and the format given the filename and extension. For example, "ko.xml" will generate a Korean language file for Android.'
+        opts.separator '- generate-string-file'
+        opts.separator '    Generates a string file in a certain LANGUAGE given a particular FORMAT. This script will attempt to guess both the language and the format given the filename and extension. For example, "ko.xml" will generate a Korean language file for Android.'
         opts.separator ''
-        opts.separator 'generate-all-string-files -- Generates all the string files necessary for a given project. The parent directory to all of the locale-specific directories in your project should be specified as the INPUT_OR_OUTPUT_PATH. This command will most often be executed by your build script so that each build always contains the most recent strings.'
+        opts.separator '- generate-all-string-files'
+        opts.separator '    Generates all the string files necessary for a given project. The parent directory to all of the locale-specific directories in your project should be specified as the INPUT_OR_OUTPUT_PATH. This command will most often be executed by your build script so that each build always contains the most recent strings.'
         opts.separator ''
-        opts.separator 'consume-string-file -- Slurps all of the strings from a translated strings file into the specified STRINGS_FILE. If you have some files returned to you by your translators you can use this command to incorporate all of their changes. This script will attempt to guess both the language and the format given the filename and extension. For example, "ja.strings" will assume that the file is a Japanese iOS strings file.'
+        opts.separator '- consume-string-file'
+        opts.separator '    Slurps all of the strings from a translated strings file into the specified STRINGS_FILE. If you have some files returned to you by your translators you can use this command to incorporate all of their changes. This script will attempt to guess both the language and the format given the filename and extension. For example, "ja.strings" will assume that the file is a Japanese iOS strings file.'
         opts.separator ''
-        opts.separator 'consume-all-string-files -- Slurps all of the strings from a directory into the specified STRINGS_FILE. If you have some files returned to you by your translators you can use this command to incorporate all of their changes. This script will attempt to guess both the language and the format given the filename and extension. For example, "ja.strings" will assume that the file is a Japanese iOS strings file.'
+        opts.separator '- consume-all-string-files'
+        opts.separator '    Slurps all of the strings from a directory into the specified STRINGS_FILE. If you have some files returned to you by your translators you can use this command to incorporate all of their changes. This script will attempt to guess both the language and the format given the filename and extension. For example, "ja.strings" will assume that the file is a Japanese iOS strings file.'
         opts.separator ''
-        opts.separator 'generate-loc-drop -- Generates a zip archive of strings files in any format. The purpose of this command is to create a very simple archive that can be handed off to a translation team. The translation team can unzip the archive, translate all of the strings in the archived files, zip everything back up, and then hand that final archive back to be consumed by the consume-loc-drop command.'
+        opts.separator '- generate-loc-drop'
+        opts.separator '    Generates a zip archive of strings files in any format. The purpose of this command is to create a very simple archive that can be handed off to a translation team. The translation team can unzip the archive, translate all of the strings in the archived files, zip everything back up, and then hand that final archive back to be consumed by the consume-loc-drop command.'
         opts.separator ''
-        opts.separator 'consume-loc-drop -- Consumes an archive of translated files. This archive should be in the same format as the one created by the generate-loc-drop command.'
+        opts.separator '- consume-loc-drop'
+        opts.separator '    Consumes an archive of translated files. This archive should be in the same format as the one created by the generate-loc-drop command.'
         opts.separator ''
-        opts.separator 'validate-strings-file -- Validates that the given strings file is parseable, contains no duplicates, and that every string has a tag. Exits with a non-zero exit code if those criteria are not met.'
+        opts.separator '- validate-strings-file'
+        opts.separator '    Validates that the given strings file is parseable, contains no duplicates, and that every string has a tag. Exits with a non-zero exit code if those criteria are not met.'
         opts.separator ''
         opts.separator 'General Options:'
         opts.separator ''
-        opts.on('-l', '--lang LANGUAGES', Array, 'The language code(s) to use for the specified action.') do |langs|
-          options[:languages] = langs
+        opts.on('-l', '--lang LANGUAGES', Array, 'The language code(s) to use for the specified action.') do |l|
+          options[:languages] = l
         end
-        opts.on('-t', '--tags TAGS', Array, 'The tag(s) to use for the specified action. Only strings with that tag will be processed. Do not specify any tags to match all strings in the strings data file.') do |tags|
-          options[:tags] = tags
+        opts.on('-t', '--tags TAG1,TAG2,TAG3', Array, 'The tag(s) to use for the specified action. Only strings with that tag will be processed. Omit this option to match',
+                                                      '  all strings in the strings data file.') do |t|
+          options[:tags] = t
         end
-        opts.on('-u', '--untagged', 'If you have specified tags using the --tags flag, then only those tags will be selected. If you also want to select all strings that are untagged, then you can specify this option to do so.') do |u|
-          options[:untagged] = true
+        opts.on('-u', '--[no-]untagged', 'If you have specified tags using the --tags flag, then only those tags will be selected. If you also want to select',
+                                         '  all strings that are untagged, then you can specify this option to do so.') do |u|
+          options[:untagged] = u
         end
-        formats = Formatters.formatters.map(&:format_name)
-        opts.on('-f', '--format FORMAT', "The file format to read or write (#{formats.join(', ')}). Additional formatters can be placed in the formats/ directory.") do |format|
-          unless formats.include?(format.downcase)
-            raise Twine::Error.new "Invalid format: #{format}"
-          end
-          options[:format] = format.downcase
+        formats = Formatters.formatters.map(&:format_name).map(&:downcase)
+        opts.on('-f', '--format FORMAT', formats, "The file format to read or write: (#{formats.join(', ')}).",
+                                                  "  Additional formatters can be placed in the formats/ directory.") do |f|
+          options[:format] = f
         end
-        opts.on('-a', '--consume-all', 'Normally, when consuming a string file, Twine will ignore any string keys that do not exist in your master file.') do |a|
+        opts.on('-a', '--[no-]consume-all', 'Normally, when consuming a string file, Twine will ignore any string keys that do not exist in your master file.') do |a|
           options[:consume_all] = true
         end
-        opts.on('-i', '--include SET', "This flag will determine which strings are included when generating strings files. It's possible values:",
+        opts.on('-i', '--include SET', [:all, :translated, :untranslated],
+                                        "This flag will determine which strings are included when generating strings files. It's possible values:",
                                         "  all: All strings both translated and untranslated for the specified language are included. This is the default value.",
                                         "  translated: Only translated strings are included.",
-                                        "  untranslated: Only untranslated strings are included.") do |set|
-          unless ['all', 'translated', 'untranslated'].include?(set.downcase)
-            raise Twine::Error.new "Invalid include flag: #{set}"
-          end
-          options[:include] = set.downcase
+                                        "  untranslated: Only untranslated strings are included.") do |i|
+          options[:include] = i
         end
-        unless options[:include]
-          options[:include] = 'all' 
-        end
-        opts.on('-o', '--output-file OUTPUT_FILE', 'Write the new strings database to this file instead of replacing the original file. This flag is only useful when running the consume-string-file or consume-loc-drop commands.') do |o|
+        opts.on('-o', '--output-file OUTPUT_FILE', 'Write the new strings database to this file instead of replacing the original file. This flag is only useful when',
+                                                   '  running the consume-string-file or consume-loc-drop commands.') do |o|
           options[:output_path] = o
         end
         opts.on('-n', '--file-name FILE_NAME', 'When running the generate-all-string-files command, this flag may be used to overwrite the default file name of the format.') do |n|
           options[:file_name] = n
         end
-        opts.on('-r', '--create-folders', "When running the generate-all-string-files command, this flag may be used to create output folders for all languages, if they don't exist yet. As a result all languages will be exported, not only the ones where an output folder already exists.") do |r|
-          options[:create_folders] = true
+        opts.on('-r', '--[no-]create-folders', "When running the generate-all-string-files command, this flag may be used to create output folders for all languages,",
+                                               "  if they  don't exist yet. As a result all languages will be exported, not only the ones where an output folder already",
+                                               "  exists.") do |r|
+          options[:create_folders] = r
         end
-        opts.on('-d', '--developer-language LANG', 'When writing the strings data file, set the specified language as the "developer language". In practice, this just means that this language will appear first in the strings data file. When generating files this language will be used as default language and its translations will be used if a key is not localized for the output language.') do |d|
+        opts.on('-d', '--developer-language LANG', 'When writing the strings data file, set the specified language as the "developer language". In practice, this just',
+                                                   '  means that this language will appear first in the strings data file. When generating files this language will be',
+                                                   '  used as default language and its translations will be used if a key is not localized for the output language.') do |d|
           options[:developer_language] = d
         end
-        opts.on('-c', '--consume-comments', 'Normally, when consuming a string file, Twine will ignore all comments in the file. With this flag set, any comments encountered will be read and parsed into the strings data file. This is especially useful when creating your first strings data file from an existing project.') do |c|
-          options[:consume_comments] = true
+        opts.on('-c', '--[no-]consume-comments', 'Normally, when consuming a string file, Twine will ignore all comments in the file. With this flag set, any comments',
+                                                 '  encountered will be read and parsed into the strings data file. This is especially useful when creating your first',
+                                                 '  strings data file from an existing project.') do |c|
+          options[:consume_comments] = c
         end
-        opts.on('-e', '--encoding ENCODING', 'Twine defaults to encoding all output files in UTF-8. This flag will tell Twine to use an alternate encoding for these files. For example, you could use this to write Apple .strings files in UTF-16. When reading files, Twine does its best to determine the encoding automatically. However, if the files are UTF-16 without BOM, you need to specify if it\'s UTF-16LE or UTF16-BE.') do |e|
+        opts.on('-e', '--encoding ENCODING', 'Twine defaults to encoding all output files in UTF-8. This flag will tell Twine to use an alternate encoding for these',
+                                             '  files. For example, you could use this to write Apple .strings files in UTF-16. When reading files, Twine does its best',
+                                             "  to determine the encoding automatically. However, if the files are UTF-16 without BOM, you need to specify if it's", 
+                                             '  UTF-16LE or UTF16-BE.') do |e|
           options[:output_encoding] = e
         end
-        opts.on('--validate', 'Validate the strings file before formatting it') do
-          options[:validate] = true
+        opts.on('--[no-]validate', 'Validate the strings file before formatting it.') do |validate|
+          options[:validate] = validate
         end
-        opts.on('-p', '--pedantic', 'When validating a strings file, perform additional checks that go beyond pure validity (like presence of tags)') do
-          options[:pedantic] = true
+        opts.on('-p', '--[no-]pedantic', 'When validating a strings file, perform additional checks that go beyond pure validity (like presence of tags).') do |p|
+          options[:pedantic] = p
         end
         opts.on('-h', '--help', 'Show this message.') do |h|
           puts opts.help
           exit
         end
-        opts.on('--version', 'Print the version number and exit.') do |x|
+        opts.on('--version', 'Print the version number and exit.') do
           puts "Twine version #{Twine::VERSION}"
           exit
         end
@@ -111,11 +124,16 @@ module Twine
         opts.separator '> twine consume-loc-drop strings.txt LocDrop5.zip'
         opts.separator '> twine validate-strings-file strings.txt'
       end
-      parser.parse! args
+      begin
+        parser.parse! args
+      rescue OptionParser::ParseError => e
+        Twine::stderr.puts e.message
+        exit false
+      end
 
       if args.length == 0
         puts parser.help
-        exit
+        exit false
       end
 
       number_of_needed_arguments = NEEDED_COMMAND_ARGUMENTS[args[0]]

--- a/lib/twine/output_processor.rb
+++ b/lib/twine/output_processor.rb
@@ -31,9 +31,9 @@ module Twine
 
             value = row.translated_string_for_lang(language)
 
-            next if value && @options[:include] == 'untranslated'
+            next if value && @options[:include] == :untranslated
 
-            if value.nil? && @options[:include] != 'translated'
+            if value.nil? && @options[:include] != :translated
               value = row.translated_string_for_lang(fallback_languages(language))
             end
 

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -211,7 +211,7 @@ class CLITestCase < TwineTestCase
 
     def test_default_options
       parse_with ''
-      expected = {command: 'validate-strings-file', strings_file: 'input.txt', include: "all"}
+      expected = {command: 'validate-strings-file', strings_file: 'input.txt', include: :all}
       assert_equal expected, @options
     end
 
@@ -266,26 +266,14 @@ class CLITestCase < TwineTestCase
     end
 
     def test_format
-      random_format = Twine::Formatters.formatters.sample.format_name
+      random_format = Twine::Formatters.formatters.sample.format_name.downcase
       parse_with "--format #{random_format}"
       assert_equal random_format, @options[:format]
     end
 
-    def test_format_ignores_case
-      random_format = Twine::Formatters.formatters.sample.format_name
-      parse_with "--format #{random_format.upcase}"
-      assert_equal random_format, @options[:format]
-    end
-
     def test_include
-      random_set = ['all', 'translated', 'untranslated'].sample
+      random_set = [:all, :translated, :untranslated].sample
       parse_with "--include #{random_set}"
-      assert_equal random_set, @options[:include]
-    end
-
-    def test_include_ignores_case
-      random_set = ['all', 'translated', 'untranslated'].sample
-      parse_with "--include #{random_set.upcase}"
       assert_equal random_set, @options[:include]
     end
 

--- a/test/test_output_processor.rb
+++ b/test/test_output_processor.rb
@@ -43,14 +43,14 @@ class TestOutputProcessor < TwineTestCase
   end
 
   def test_include_translated
-    processor = Twine::Processors::OutputProcessor.new(@strings, { include: 'translated' })
+    processor = Twine::Processors::OutputProcessor.new(@strings, { include: :translated })
     result = processor.process('fr')
 
     assert_equal %w(key4), result.strings_map.keys.sort
   end
 
   def test_include_untranslated
-    processor = Twine::Processors::OutputProcessor.new(@strings, { include: 'untranslated' })
+    processor = Twine::Processors::OutputProcessor.new(@strings, { include: :untranslated })
     result = processor.process('fr')
 
     assert_equal %w(key1 key2 key3), result.strings_map.keys.sort


### PR DESCRIPTION
After this PR the output of `twine --help` should look nicer and some shells should even provide autocompletion for some options.