### PR TITLE
Fixed #145

### DIFF
--- a/lib/twine/formatters.rb
+++ b/lib/twine/formatters.rb
@@ -19,6 +19,7 @@ module Twine
   end
 end
 
+require File.join(File.dirname(__FILE__), 'formatters', 'abstract.rb')
 Dir[File.join(File.dirname(__FILE__), 'formatters', '*.rb')].each do |file|
   require file
 end


### PR DESCRIPTION
`Dir[]` does not return the files in alphabetical order on Ubuntu, so `Android` is loaded before `Abstract` which leads to a "uninitialized constant" error. This PR ensures `Abstract` is always loaded first.