### PR TITLE
Remove empty sections before joining them together

### DIFF
--- a/lib/twine/formatters/jquery.rb
+++ b/lib/twine/formatters/jquery.rb
@@ -50,6 +50,7 @@ module Twine
 
       def format_sections(strings, lang)
         sections = strings.sections.map { |section| format_section(section, lang) }
+        sections.delete_if &:empty?
         sections.join(",\n\n")
       end
 


### PR DESCRIPTION
Previously, a comma was being printed on the last line of every section, even if that section did not contribute any rows to the formatted output (e.g., no rows within that section had the tags needed to be output during this run). When such a zero-row section happens, the formatter prints a line with only a comma on it, which is not valid JSON. This can make incremental adjustment of the query files rather tedious, even when using gui tools to quickly reject changes.

As an example, the following twine_strings.txt

```
 [[Section1]]
	[s1r1]
		en = Section 1, Row 1
		tags = iOS

[[Section2]]
	[s2r1]
		en = Section 2, Row 1
		tags = iOS,web
```

resulted in the following JSON output when I call `twine generate-string-file twine_strings.txt twine.json --format jquery --tags web --lang en`:

```
{
,

"s2r1":"Section 2, Row 1"
}

```