### PR TITLE
Fix placeholder parser mistaking '% d' for '%d'

### DIFF
--- a/lib/twine/placeholders.rb
+++ b/lib/twine/placeholders.rb
@@ -2,7 +2,7 @@ module Twine
   module Placeholders
     extend self
 
-    PLACEHOLDER_FLAGS_WIDTH_PRECISION_LENGTH = '([-+ 0#])?(\d+|\*)?(\.(\d+|\*))?(hh?|ll?|L|z|j|t)?'
+    PLACEHOLDER_FLAGS_WIDTH_PRECISION_LENGTH = '([-+0#])?(\d+|\*)?(\.(\d+|\*))?(hh?|ll?|L|z|j|t)?'
     PLACEHOLDER_PARAMETER_FLAGS_WIDTH_PRECISION_LENGTH = '(\d+\$)?' + PLACEHOLDER_FLAGS_WIDTH_PRECISION_LENGTH
 
     # http://developer.android.com/guide/topics/resources/string-resource.html#FormattingAndStyling

--- a/test/test_formatters.rb
+++ b/test/test_formatters.rb
@@ -39,7 +39,7 @@ end
 class TestAndroidFormatter < FormatterTest
   def setup
     super Twine::Formatters::Android
-    
+
     @escape_test_values = {
       'this & that'               => 'this &amp; that',
       'this < that'               => 'this &lt; that',
@@ -135,6 +135,11 @@ class TestAndroidFormatter < FormatterTest
   def test_format_value_does_not_modify_resource_identifiers
     identifier = '@android:string/cancel'
     assert_equal identifier, @formatter.format_value(identifier)
+  end
+
+  def test_does_not_replace_single_percent_signs_when_followed_by_space_and_format_letter
+    # Said differently: formartter parser should not recognize %a in "70% and"
+    assert_equal 'If 70% and 30% dog 80% end', @formatter.format_value('If 70% and 30% dog 80% end')
   end
 
   def test_deducts_language_from_resource_folder


### PR DESCRIPTION
I removed the space from the PLACEHOLDER_FLAGS_WIDTH_PRECISION_LENGTH regex and that didn't lead to any error in the tests, so I'm not sure why it was there in the first place.

What's for sure is that leaving it causes unexpected results if a figure with a % is followed by a word that starts with a letter used in a placeholder, for instance "% a" in "70% and" will be mistaken for the "%a" placeholder.