### PR TITLE
fix flash formatter does not recognize most valid printf placeholder

### DIFF
--- a/lib/twine/formatters/flash.rb
+++ b/lib/twine/formatters/flash.rb
@@ -66,7 +66,7 @@ module Twine
 
       def format_value(value)
         placeHolderNumber = -1
-        value.gsub(/%[d@]/) { placeHolderNumber += 1; '{%d}' % placeHolderNumber }
+        value.gsub(/%(?:\d+\$)?((\.(\d)?\d)|.)?[dfsu@]/) { placeHolderNumber += 1; '{%d}' % placeHolderNumber }
       end
     end
   end


### PR DESCRIPTION
flash (properties) formatter does not recognize most valid placeholder.
This change permit to recognize all these valid placeholder and export a valid properties file:
%f
%.f
%.1f
%.2f
%.02f
%.3f
%.03f
%2$.f
%2$.2f
%2$.02f
%2$f
%1$.2f
